### PR TITLE
Initial extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.8
 COPY ./Makefile ./Makefile
 RUN make docker
 COPY ./ws_server.py ./ws_server.py
-EXPOSE 80
+EXPOSE 8081
 
 CMD [ "uwsgi", "/app/config.yml" ]

--- a/config.yml
+++ b/config.yml
@@ -4,9 +4,6 @@ eth2_api: http://mainnet-lodestar-520_beacon_node_1:9596
 # Optional graffiti to display in your JSON response
 ws_server_graffiti: 
 
-# Minimum number of epochs between consecutive updates of the cached weak subjectivity data
-min_cache_update_epochs: 10
-
 # Hostname for Redis server
 redis: redis
 
@@ -14,5 +11,6 @@ redis: redis
 uwsgi:
   wsgi: ws_server:app
   http: 0.0.0.0:8081
+  http-timeout: 3000
   processes: 1
   threads: 1

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
 # Eth2 API endpoint
-eth2_api: http://<IP>:<PORT>
+eth2_api: http://mainnet-lodestar-520_beacon_node_1:9596
 
 # Optional graffiti to display in your JSON response
 ws_server_graffiti: 
@@ -13,6 +13,6 @@ redis: redis
 # uwsgi server configuration
 uwsgi:
   wsgi: ws_server:app
-  http: 0.0.0.0:80
+  http: 0.0.0.0:8081
   processes: 1
   threads: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,14 @@ services:
     ports:
       - 6379
     networks:
-      - ws_network
+      - lodestar_default
   eth2_ws_server:
     build:
       context: .
       dockerfile: Dockerfile
     image: "eth2_ws_server"
     networks:
-      - ws_network
+      - lodestar_default
     volumes:
       - .:/app
     depends_on:
@@ -23,5 +23,5 @@ services:
 
 networks:
   # NOTE: this assumes that the user has already greated the ws_network and has also confiured the lodestar docker-compose.yml to use the same network
-  ws_network:
+  lodestar_default:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,17 +5,15 @@ services:
     image: "redis"
     ports:
       - 6379
-    # network_mode: host
     networks:
-      - my-external-network
+      - ws_network
   eth2_ws_server:
     build:
       context: .
       dockerfile: Dockerfile
     image: "eth2_ws_server"
-    # network_mode: host
     networks:
-      - my-external-network
+      - ws_network
     volumes:
       - .:/app
     depends_on:
@@ -24,5 +22,6 @@ services:
       - "0.0.0.0:8081:8081"
 
 networks:
-  my-external-network:
+  # NOTE: this assumes that the user has already greated the ws_network and has also confiured the lodestar docker-compose.yml to use the same network
+  ws_network:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,24 @@ services:
     image: "redis"
     ports:
       - 6379
+    # network_mode: host
+    networks:
+      - my-external-network
   eth2_ws_server:
     build:
       context: .
       dockerfile: Dockerfile
     image: "eth2_ws_server"
+    # network_mode: host
+    networks:
+      - my-external-network
     volumes:
       - .:/app
     depends_on:
       - redis
     ports:
-      - "0.0.0.0:80:80"
+      - "0.0.0.0:8081:8081"
+
+networks:
+  my-external-network:
+    external: true

--- a/ws_server.py
+++ b/ws_server.py
@@ -53,7 +53,7 @@ def get_current_epoch():
 
 def get_finalized_checkpoint():
     finality_checkpoints = query_eth2_api(
-        '/eth/v1/beacon/states/finalized/finality_checkpoints'
+        '/eth/v1/beacon/states/head/finality_checkpoints'
         )
     finalized_checkpoint = finality_checkpoints["data"]["finalized"]
     logging.info(f'finalized_checkpoint: {finalized_checkpoint}')

--- a/ws_server.py
+++ b/ws_server.py
@@ -173,15 +173,9 @@ def get_ws_data(checkpoint: Checkpoint):
     ws_period = compute_weak_subjectivity_period(active_validator_count,
                                                  avg_validator_balance)
     logging.debug(f"Computed WS period: {ws_period}")
-    ws_state = None
-    if checkpoint.epoch is not None:
-        ws_state = query_eth2_api(
-            f'/eth/v1/debug/beacon/states/{checkpoint.epoch * 32}'
-        )
-    else:
-        ws_state = query_eth2_api(
-            f'/eth/v1/debug/beacon/states/finalized'
-        )
+    ws_state = query_eth2_api(
+        f'/eth/v1/debug/beacon/states/{finalized_epoch * 32}'
+    )
     ws_data = {
         "finalized_epoch": finalized_epoch,
         "ws_checkpoint": f'{finalized_block_root}:{finalized_epoch}',

--- a/ws_server.py
+++ b/ws_server.py
@@ -7,30 +7,26 @@ from eth2spec.phase0.spec import (
     MIN_PER_EPOCH_CHURN_LIMIT, MIN_VALIDATOR_WITHDRAWABILITY_DELAY,
     SAFETY_DECAY, SECONDS_PER_SLOT, SLOTS_PER_EPOCH
 )
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 import redis
 import time
-import json
 import logging
 import yaml
 
 with open("/app/config.yml", "r") as config_file:
     cfg = yaml.safe_load(config_file)
 logging.basicConfig(format='%(asctime)s -- %(levelname)s -- %(message)s')
-logging.getLogger().setLevel(logging.INFO)
+logging.getLogger().setLevel(logging.DEBUG)
 r = redis.Redis(host='redis')
 # ETH2_API is the Eth2 beacon node's HTTP endpoint
 ETH2_API = cfg["eth2_api"]
-# MIN_CACHE_UPDATE_EPOCHS is the minimum number of epochs between consecutive
-# updates of the cached weak subjectivity data
-MIN_CACHE_UPDATE_EPOCHS = int(cfg["min_cache_update_epochs"])
 # Optional graffiti to serve in the HTTP JSON response
 WS_SERVER_GRAFFITI = cfg["ws_server_graffiti"]
 
 
 def query_eth2_api(endpoint):
     url = ETH2_API + endpoint
-    response = httpx.get(url, timeout=100)
+    response = httpx.get(url, timeout=None)
     if response.status_code != 200:
         raise Exception(
             f"GET {url} returned with status code {response.status_code}"
@@ -152,12 +148,21 @@ def atomic_get_finalized_checkpoint_and_validator_info():
     return finalized_checkpoint, active_validator_count, avg_validator_balance
 
 
-def update_ws_data_cache():
+def get_ws_data(checkpoint = None):
     logging.info(f'Fetching weak subjectivity data from {ETH2_API}')
     finalized_checkpoint, active_validator_count, avg_validator_balance = \
         atomic_get_finalized_checkpoint_and_validator_info()
-    finalized_epoch = int(finalized_checkpoint["epoch"])
-    finalized_block_root = finalized_checkpoint["root"]
+    finalized_epoch = None
+    finalized_block_root = None
+    if checkpoint is None:
+        finalized_epoch = int(finalized_checkpoint["epoch"])
+        finalized_block_root = finalized_checkpoint["root"]
+    else:
+        # TODO: validate checkpointData
+        checkpointData = checkpoint.split(":")
+        logging.info(f"checkpointData: {checkpointData}")
+        finalized_epoch = int(checkpointData[1])
+        finalized_block_root = checkpointData[0]
     logging.debug(f'Got data from {ETH2_API} - '
                   'finalized epoch: {finalized_epoch}, '
                   'active val. count: {active_validator_count}, '
@@ -174,60 +179,11 @@ def update_ws_data_cache():
         "ws_period": ws_period,
         "ws_state": ws_state,
     }
-    current_epoch = get_current_epoch()
-    ws_data_cache = {
-        "caching_epoch": current_epoch,
-        "ws_data": ws_data
-    }
-    logging.info(
-        f"Updating redis cache key 'ws_data_cache' with {ws_data_cache}"
-    )
-    r.set('ws_data_cache', json.dumps(ws_data_cache))
     return ws_data
 
 
-def get_ws_data():
-    ws_data_cache_bytes = r.get('ws_data_cache')
-    # If redis cache is empty, initialize it
-    if ws_data_cache_bytes is None:
-        logging.debug(
-            "No 'ws_data_cache' in cache. Initializing cache now."
-        )
-        return update_ws_data_cache()
-    ws_data_cache = json.loads(ws_data_cache_bytes.decode('utf-8'))
-    logging.debug(
-        f"Got from redis cache for key 'ws_data_cache': {ws_data_cache}"
-    )
-    # Refresh redis cache if it has been more than MIN_CACHE_UPDATE_EPOCHS
-    # since last update
-    current_epoch = get_current_epoch()
-    cache_expired = (
-        current_epoch - ws_data_cache["caching_epoch"]
-        > MIN_CACHE_UPDATE_EPOCHS
-    )
-    if cache_expired:
-        logging.debug(
-            "Cached value for 'ws_data_cache' has expired - "
-            f"ws_data_cache: {ws_data_cache}, current epoch: {current_epoch}"
-        )
-        return update_ws_data_cache()
-    ws_data = ws_data_cache["ws_data"]
-    # Refresh redis cache if the current epoch is outside of the WS safety
-    # period since last update
-    current_epoch_in_ws_period = (
-        current_epoch - ws_data["finalized_epoch"] < ws_data["ws_period"]
-    )
-    if not current_epoch_in_ws_period:
-        logging.info(
-            "Cached value for 'ws_data_cache' is unsafe - "
-            f"ws_data_cache: {ws_data_cache}, current epoch: {current_epoch}"
-        )
-        return update_ws_data_cache()
-    return ws_data
-
-
-def prepare_response():
-    ws_data = get_ws_data()
+def prepare_response(checkpoint):
+    ws_data = get_ws_data(checkpoint)
     current_epoch = get_current_epoch()
     current_epoch_in_ws_period = (
         current_epoch - ws_data["finalized_epoch"] < ws_data["ws_period"]
@@ -247,7 +203,7 @@ def prepare_response():
 # Update redis cache on startup
 logging.info("Initializing cache. Server will be ready soon.")
 get_current_epoch()
-update_ws_data_cache()
+# get_ws_data()
 logging.info("Cache initialized. Ready to serve requests.")
 
 app = Flask(__name__)
@@ -255,4 +211,5 @@ app = Flask(__name__)
 
 @app.route('/')
 def serve_ws_data():
-    return jsonify(prepare_response())
+    checkpoint = request.args.get('checkpoint')
+    return jsonify(prepare_response(checkpoint))


### PR DESCRIPTION
DO NOT MERGE UNTIL APPROVED!  @wemeetagain  please set up merge protections, when you get the chance?

WIP. an eventual replacement of @chainsafe/beacon-state-upload

based on convo had here:
https://discord.com/channels/593655374469660673/593655641445367808/845030101501870120

A consumer of this API can make a call to `/` and get the latest ws checkpoint, and can also pass a query, `checkpoint` in the form of `<weakSubjectivityblockRootAsHex>:<epoch>` (e.g. `/?checkpoint=0xDEADBEEF:1234`) and the API will ask the beacon node for the ws checkpoint at the specified epoch.

I removed the caching since we are extending the solution to allow users to fetch from any point within the weak subjectivity period.

Also fixes a flaw from the original codebase that was fetching the finalized checkpoint from `{ETH2_API_ROOT}/finalized/finality_checkpoints` instead of `{ETH2_API_ROOT}/head/finality_checkpoints`